### PR TITLE
fix(zsh): resolve tmux-xpanes startup error

### DIFF
--- a/.config/zsh/zinit.zsh
+++ b/.config/zsh/zinit.zsh
@@ -52,7 +52,8 @@ zinit light mollifier/cd-gitroot
 zinit ice wait'3' lucid as"program" pick"bin/git-dsf"
 zinit light zdharma-continuum/zsh-diff-so-fancy
 
-zinit ice wait'3' lucid
+zinit ice wait'3' lucid as"program" pick"bin/xpanes" \
+  atload"alias tmux-xpanes=xpanes; fpath+=(${ZINIT_HOME:h}/plugins/greymd---tmux-xpanes/completion/zsh); autoload -Uz _xpanes; compdef _xpanes xpanes"
 zinit light greymd/tmux-xpanes
 
 zinit ice wait'4' lucid as"program" pick"src/batman.sh" atload"alias man=batman.sh"


### PR DESCRIPTION
## Description

Fixes startup errors related to `tmux-xpanes` plugin in Zsh.

### Issue
The `tmux-xpanes` plugin script was being sourced directly, causing `dirname: write error: Bad file descriptor` and file not found errors because it wasn't designed to be sourced in this context.

### Fix
- Changed loading method to `as"program"` and pick only the binary `bin/xpanes`.
- Added an `atload` hook to manually set up the alias (`tmux-xpanes=xpanes`), add the completion directory to `fpath`, and register the completion function (`_xpanes`).

### Verification
- No more error messages on shell startup.
- `xpanes` command works.
- `tmux-xpanes` alias works.
- Completion for `xpanes` works.
